### PR TITLE
Add version management in PatrowlEngine

### DIFF
--- a/PatrowlEnginesUtils/PatrowlEngine.py
+++ b/PatrowlEnginesUtils/PatrowlEngine.py
@@ -279,7 +279,9 @@ class PatrowlEngine:
             return jsonify(res)
 
         for t in self.scans[scan_id]['threads']:
-            t._Thread__stop()
+            t.join()
+            self.scans[scan_id]['threads'].remove(t)
+            # t._Thread__stop()
         self.scans[scan_id]['status'] = "STOPPED"
         self.scans[scan_id]['finished_at'] = int(time.time() * 1000)
 
@@ -351,7 +353,6 @@ class PatrowlEngine:
         issues = []
         summary = {}
 
-        # scan = self.scans[scan_id]
         nb_vulns = {
             "info": 0,
             "low": 0,
@@ -480,13 +481,13 @@ class PatrowlEngineFinding:
             "target": {
                 "addr": self.target_addrs,
                 "protocol": self.target_proto
-                },
+            },
             "metadata": {
                 "tags": self.meta_tags,
                 "links": self.meta_links,
                 "vuln_refs": self.meta_vuln_refs,
                 "risk": self.meta_risk
-                },
+            },
             "raw": self.raw,
             "timestamp": self.timestamp
         }

--- a/PatrowlEnginesUtils/PatrowlEngine.py
+++ b/PatrowlEnginesUtils/PatrowlEngine.py
@@ -33,12 +33,12 @@ def _json_serial(obj):
 class PatrowlEngine:
     """Class definition of PatrowlEngine."""
 
-    def __init__(self, app, base_dir, name, max_scans=DEFAULT_APP_MAXSCANS):
+    def __init__(self, app, base_dir, name, max_scans=DEFAULT_APP_MAXSCANS, version=0):
         """Initialise a new PatrowlEngine."""
         self.app = app
         self.base_dir = str(base_dir)
         self.name = name
-        self.version = 0
+        self.version = version
         self.description = ""
         self.allowed_asset_types = []
         self.options = {}

--- a/PatrowlEnginesUtils/PatrowlEngineTest.py
+++ b/PatrowlEnginesUtils/PatrowlEngineTest.py
@@ -98,16 +98,15 @@ class PatrowlEngineTest:
             return r.json()
 
     def custom_test(self, test_name, assets, scan_policy=None, is_valid=True,
-                    max_timeout=1200):
+                    max_timeout=1200, scan_id=random.randint(1000000, 1999999)):
         """Start a custom test."""
         print("test-{}-custom: {}".format(self.engine_name, test_name))
-        TEST_SCAN_ID = random.randint(1000000, 1999999)
-        if(scan_policy == None):
+        if scan_policy is None:
             scan_policy = {}
         post_data = {
             "assets":  assets,
             "options": scan_policy,
-            "scan_id": str(TEST_SCAN_ID)
+            "scan_id": str(scan_id)
         }
 
         r = requests.post(
@@ -131,7 +130,7 @@ class PatrowlEngineTest:
         has_error = False
         while time.time() < timeout_start + max_timeout:
             r = requests.get(
-                url="{}/status/{}".format(self.base_url, TEST_SCAN_ID))
+                url="{}/status/{}".format(self.base_url, scan_id))
             if r.json()["status"] in ("SCANNING", "STARTED"):
                 time.sleep(3)
             elif (r.json()["status"] == "ERROR" and "reason" in r.json() and
@@ -150,7 +149,7 @@ class PatrowlEngineTest:
         if not has_error:
             findings = {}
             r = requests.get(
-                url="{}/getfindings/{}".format(self.base_url, TEST_SCAN_ID))
+                url="{}/getfindings/{}".format(self.base_url, scan_id))
             try:
                 assert r.json()['status'] == "success"
                 findings = r.json()
@@ -160,7 +159,7 @@ class PatrowlEngineTest:
 
             # Get report
             r = requests.get(
-                url="{}/getreport/{}".format(self.base_url, TEST_SCAN_ID))
+                url="{}/getreport/{}".format(self.base_url, scan_id))
             try:
                 # check the file name & siza !!
                 assert True

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='PatrowlEnginesUtils',
-    version='1.0.0dev',
+    version='1.0.1',
     description='Common classes for PatrowlEngines',
     url='https://github.com/Patrowl/PatrowlEnginesUtils',
     author='Nicolas Mattiocco',


### PR DESCRIPTION
**Features**:
  - Add version optional field in PatrowlEngine, useful to specify a cusom version instead of "0" in /engines/xxxx/info