### PR TITLE
[PatrowlEngineUtils]: Update isAlive to is_alive method for thread

### DIFF
--- a/PatrowlEnginesUtils/PatrowlEngine.py
+++ b/PatrowlEnginesUtils/PatrowlEngine.py
@@ -222,7 +222,7 @@ class PatrowlEngine:
 
         all_threads_finished = True
         for t in self.scans[scan_id]['threads']:
-            if t.isAlive():
+            if t.is_alive():
                 all_threads_finished = False
                 break
 

--- a/PatrowlEnginesUtils/__init__.py
+++ b/PatrowlEnginesUtils/__init__.py
@@ -3,7 +3,7 @@
 
 
 __title__ = 'patrowl_engine_utils'
-__version__ = '1.0.0'
+__version__ = '1.0.2'
 __author__ = 'Nicolas MATTIOCCO'
 __license__ = 'AGPLv3'
 __copyright__ = 'Copyright (C) 2018-2020 Nicolas Mattiocco - @MaKyOtOx'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='PatrowlEnginesUtils',
-    version='1.0.1',
+    version='1.0.2',
     description='Common classes for PatrowlEngines',
     url='https://github.com/Patrowl/PatrowlEnginesUtils',
     author='Nicolas Mattiocco',


### PR DESCRIPTION
Thread.isAlive() has been deprecated since python 3 and has been removed
since python 3.9
We have to use `is_alive()` now.

Signed-off-by: Fabien Martinez <fabien.martinez@adevinta.com>